### PR TITLE
Add support for custom Steam App ID in ARS rebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ servers/
 notes.txt
 
 dist/
+app-config.json

--- a/ars/Dockerfile
+++ b/ars/Dockerfile
@@ -1,11 +1,14 @@
 # steamcmd/steamcmd:latest is based on ubuntu
 FROM steamcmd/steamcmd:latest
 
+# Build argument for Steam app ID (defaults to stable Arma Reforger Server)
+ARG STEAM_APP_ID=1874900
+
 # set 'root' as current user
 USER root
 
 # install Arma Reforger Server with steamcmd to /ars
-RUN steamcmd +force_install_dir /ars +login anonymous +app_update 1874900 validate +quit
+RUN steamcmd +force_install_dir /ars +login anonymous +app_update ${STEAM_APP_ID} validate +quit
 
 # change owner of /ars to ubuntu user and group to allow executing it
 RUN chown -R ubuntu:ubuntu /ars

--- a/src/arsa.ts
+++ b/src/arsa.ts
@@ -17,6 +17,8 @@ export class ArmaReforgerServerAdmin {
 	arsList: ArmaReforgerServer[] = [];
 	publicIp: string = '';
 	messageQueue: ServerStatusUpdate[] = [];
+	currentSteamAppId: number = 1874900; // Track current Steam App ID for Docker builds
+	lastDockerBuild?: { steamAppId: number; timestamp: number };
 
 	constructor() {
 		this.inspectARS();
@@ -94,8 +96,13 @@ export class ArmaReforgerServerAdmin {
 		this.setArsStatus(ArsStatus.RECREATING);
 		this.sendArsStatusUpdate();
 
-		// Use provided steamAppId or default to stable version
-		const appId = steamAppId || 1874900;
+		// Use provided steamAppId or current setting
+		const appId = steamAppId || this.currentSteamAppId;
+
+		// Update current setting if provided
+		if (steamAppId) {
+			this.currentSteamAppId = steamAppId;
+		}
 
 		// STEP 1
 		this.logAndSendMessage('Stopping all ars instances...');
@@ -208,8 +215,45 @@ export class ArmaReforgerServerAdmin {
 			return;
 		}
 
+		// Track successful build
+		this.lastDockerBuild = {
+			steamAppId: appId,
+			timestamp: Date.now(),
+		};
+
 		this.setArsStatus(ArsStatus.AVAILABLE);
 		this.sendArsStatusUpdate();
+	}
+
+	public getSteamAppId(): number {
+		return this.currentSteamAppId;
+	}
+
+	public setSteamAppId(steamAppId: number): void {
+		if (steamAppId !== 1874900 && steamAppId !== 1890870) {
+			throw new Error('Invalid steamAppId. Must be 1874900 (stable) or 1890870 (experimental)');
+		}
+		this.currentSteamAppId = steamAppId;
+	}
+
+	public getLastDockerBuild(): { steamAppId: number; timestamp: number } | undefined {
+		return this.lastDockerBuild;
+	}
+
+	public getDockerImageInfo(): { 
+		currentSteamAppId: number; 
+		lastBuild?: { steamAppId: number; timestamp: number };
+		needsRebuild: boolean;
+	} {
+		const needsRebuild = !this.lastDockerBuild || 
+			this.lastDockerBuild.steamAppId !== this.currentSteamAppId ||
+			this.arsStatus === ArsStatus.UNAVAILABLE;
+
+		return {
+			currentSteamAppId: this.currentSteamAppId,
+			lastBuild: this.lastDockerBuild,
+			needsRebuild,
+		};
 	}
 
 	logAndSendMessage(message: string) {

--- a/src/arsa.ts
+++ b/src/arsa.ts
@@ -90,9 +90,12 @@ export class ArmaReforgerServerAdmin {
 		this.sendArsStatusUpdate();
 	}
 
-	async recreateARS() {
+	async recreateARS(steamAppId?: number) {
 		this.setArsStatus(ArsStatus.RECREATING);
 		this.sendArsStatusUpdate();
+
+		// Use provided steamAppId or default to stable version
+		const appId = steamAppId || 1874900;
 
 		// STEP 1
 		this.logAndSendMessage('Stopping all ars instances...');
@@ -150,13 +153,15 @@ export class ArmaReforgerServerAdmin {
 		}
 
 		// STEP 4
-		this.logAndSendMessage('Building new ars image...');
+		this.logAndSendMessage(`Building new ars image with Steam App ID ${appId}...`);
 		const commandBuild = new Deno.Command('docker', {
 			cwd: join(Deno.cwd(), 'ars'),
 			args: [
 				'buildx',
 				'build',
 				'--no-cache',
+				'--build-arg',
+				`STEAM_APP_ID=${appId}`,
 				'-t',
 				'ars',
 				'-f',

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -5,7 +5,6 @@ export const defaultConfig: ServerConfig = {
 	bindPort: 2001,
 	publicAddress: '',
 	publicPort: 2001,
-	steamAppId: 1874900,
 	a2s: {
 		address: '0.0.0.0',
 		port: 17777,
@@ -175,6 +174,7 @@ export const defaultServer: Server = {
 	uuid: '',
 	name: '',
 	isRunning: false,
+	steamAppId: 1874900, // Default to stable version
 	config: defaultConfig,
 	startupParameters: StartupParameters,
 };

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -5,6 +5,7 @@ export const defaultConfig: ServerConfig = {
 	bindPort: 2001,
 	publicAddress: '',
 	publicPort: 2001,
+	steamAppId: 1874900,
 	a2s: {
 		address: '0.0.0.0',
 		port: 17777,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -22,6 +22,7 @@ export interface Server {
 	uuid: string;
 	name: string;
 	isRunning: boolean;
+	steamAppId?: number; // Track which Steam App ID was used to build this server
 	config?: ServerConfig;
 	startupParameters: StartupParameter[];
 }
@@ -31,7 +32,6 @@ export interface ServerConfig {
 	bindPort: number;
 	publicAddress: string;
 	publicPort: number;
-	steamAppId: number;
 	a2s: {
 		address: string;
 		port: number;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -31,6 +31,7 @@ export interface ServerConfig {
 	bindPort: number;
 	publicAddress: string;
 	publicPort: number;
+	steamAppId: number;
 	a2s: {
 		address: string;
 		port: number;

--- a/src/main.ts
+++ b/src/main.ts
@@ -314,9 +314,13 @@ if (import.meta.main) {
 		const steamAppId = c.req.query('steamAppId');
 		const appId = steamAppId ? parseInt(steamAppId, 10) : undefined;
 
+		if (appId && (appId !== 1874900 && appId !== 1890870)) {
+			return c.json({ error: 'Invalid steamAppId. Must be 1874900 (stable) or 1890870 (experimental)' }, 400);
+		}
+
 		arsa.recreateARS(appId);
 
-		return c.json({ value: true });
+		return c.json({ value: true, steamAppId: appId || arsa.getSteamAppId() });
 	});
 
 	// route for recreating ARS docker image with specific Steam app ID
@@ -336,6 +340,35 @@ if (import.meta.main) {
 		} catch (error) {
 			console.error('Error parsing request body:', error);
 			return c.json({ error: 'Invalid request body' }, 400);
+		}
+	});
+
+	/* ---------------------------------------- */
+
+	// route for getting current Steam App ID setting
+	app.get('/api/steam-app-id', (c) => {
+		console.log('Getting current Steam App ID setting...');
+		const info = arsa.getDockerImageInfo();
+		return c.json(info);
+	});
+
+	// route for setting Steam App ID (without rebuilding)
+	app.post('/api/steam-app-id', async (c) => {
+		console.log('Setting Steam App ID...');
+
+		try {
+			const body = await c.req.json();
+			const steamAppId = body.steamAppId;
+
+			arsa.setSteamAppId(steamAppId);
+			return c.json({ 
+				value: true, 
+				steamAppId,
+				info: arsa.getDockerImageInfo()
+			});
+		} catch (error) {
+			console.error('Error setting Steam App ID:', error);
+			return c.json({ error: error.message || 'Invalid request' }, 400);
 		}
 	});
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -310,9 +310,33 @@ if (import.meta.main) {
 	app.get('/api/recreate-ars-docker-image', (c) => {
 		console.log('Recreating ARS docker image started...');
 
-		arsa.recreateARS();
+		// Get optional steamAppId query parameter
+		const steamAppId = c.req.query('steamAppId');
+		const appId = steamAppId ? parseInt(steamAppId, 10) : undefined;
+
+		arsa.recreateARS(appId);
 
 		return c.json({ value: true });
+	});
+
+	// route for recreating ARS docker image with specific Steam app ID
+	app.post('/api/recreate-ars-docker-image', async (c) => {
+		console.log('Recreating ARS docker image with specific app ID started...');
+
+		try {
+			const body = await c.req.json();
+			const steamAppId = body.steamAppId;
+
+			if (steamAppId && (steamAppId === 1874900 || steamAppId === 1890870)) {
+				arsa.recreateARS(steamAppId);
+				return c.json({ value: true, steamAppId });
+			} else {
+				return c.json({ error: 'Invalid steamAppId. Must be 1874900 (stable) or 1890870 (experimental)' }, 400);
+			}
+		} catch (error) {
+			console.error('Error parsing request body:', error);
+			return c.json({ error: 'Invalid request body' }, 400);
+		}
 	});
 
 	/* ---------------------------------------- */


### PR DESCRIPTION
Dockerfile and backend now accept a build argument for Steam App ID, allowing selection between stable and experimental Arma Reforger Server versions. API endpoints updated to handle optional steamAppId parameter, with validation for allowed IDs. ServerConfig and interfaces extended to include steamAppId.

note: i will flag this as we ran into errors when executing